### PR TITLE
Update import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowcoders/react-popper",
-  "version": "0.7.93",
+  "version": "0.7.94",
   "description": "React wrapper around PopperJS.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/Popper.tsx
+++ b/src/Popper.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as PopperJS from "popper.js";
-import * as PopperJSDist from "popper.js/dist/popper";
+import * as PopperJSDist from "popper.js/dist/umd/popper";
 
 export interface IPopperChildProps {
     style: any;


### PR DESCRIPTION
Import has to be updated to reflect Popper.js's package.json's 'main' property. That's the dist file actually used when 'import Popper from 'popper.js'' is invoked. The UMD export type is compatible with ES5 environments. This should solve the build issue with uglifying the main.js file. 