### PR TITLE
Null out popper property after destruction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowcoders/react-popper",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "React wrapper around PopperJS.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/Popper.tsx
+++ b/src/Popper.tsx
@@ -30,7 +30,7 @@ export class Popper extends React.Component<IPopperProps, IPopperState> {
         },
     };
 
-    private _popper: PopperJS.default;
+    private _popper: PopperJS.default | null;
     private _arrowNode: React.ReactNode;
     private _node: Element;
     private _component: React.ReactNode;
@@ -80,7 +80,9 @@ export class Popper extends React.Component<IPopperProps, IPopperState> {
         //   this._createPopper()
         // }
 
-        this._popper.scheduleUpdate();
+        if (this._popper != null) {
+            this._popper.scheduleUpdate();
+        }
     }
 
     componentWillUnmount() {
@@ -102,6 +104,7 @@ export class Popper extends React.Component<IPopperProps, IPopperState> {
             constructor = PopperJSDist;
         }
 
+        this._destroyPopper();
         this._popper = new constructor(this._getTargetNode(), this._node, {
             ...popperProps,
             modifiers: {
@@ -131,8 +134,9 @@ export class Popper extends React.Component<IPopperProps, IPopperState> {
     }
 
     _destroyPopper() {
-        if (this._popper) {
+        if (this._popper != null) {
             this._popper.destroy();
+            this._popper = null;
         }
     }
 


### PR DESCRIPTION
After destroying the this._popper, we should set it to null so that we don't call scheduleUpdate on a destroyed object